### PR TITLE
Deploy to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ script:
 # Deploy to Github pages
 deploy:
   provider: pages
-  skip_cleanup: true
+  skip-cleanup: true
   target-branch: master
-  local_dir: public
-  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  local-dir: public
+  github-token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   on:
     branch: hugo

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
 deploy:
   provider: pages
   skip_cleanup: true
+  target-branch: master
   local_dir: public
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   on:


### PR DESCRIPTION
In order to obviate the issue with Github pages serving this from `/digital_services`, I intend to use an Organization Page (https://help.github.com/articles/user-organization-and-project-pages/) which will be served at simply `sfdigitialservices.github.io`.

After this is merged we will need to:
* Rename this repository name to `sfdigitialservices.github.io`

I have backed up the current `master` branch as `master.bak`.

Overall scheme:

* The staging site will be hosted on Github Pages on the `master` branch
* The `master` branch will contain _only_ the generated static files, a new `source` branch will contain the Hugo configuration and content used to generate the static files
* The production site will continue to be hosted internally for now (pulling updates from `master` on demand)